### PR TITLE
feat: Google Ads コンバージョントラッキング実装

### DIFF
--- a/components/CTASection.tsx
+++ b/components/CTASection.tsx
@@ -1,4 +1,21 @@
+'use client'
+
 import React from 'react'
+
+// Google Ads コンバージョン追跡関数
+declare global {
+  interface Window {
+    gtag: (command: string, ...args: any[]) => void
+  }
+}
+
+const handleConversion = () => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', 'conversion', {
+      'send_to': 'AW-617366745/sCN4CI2u6I0bENmJsaYC'
+    })
+  }
+}
 
 const CTASection = () => {
   return (
@@ -32,6 +49,7 @@ const CTASection = () => {
                   className="inline-flex items-center bg-green-600 hover:bg-green-700 text-white font-semibold py-4 px-8 rounded-lg text-lg transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1 mb-6"
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={handleConversion}
                 >
                   <span className="bg-white text-green-600 px-2 py-1 rounded text-xs mr-3 font-bold">APP</span>
                   友だち追加する

--- a/components/FAQSection.tsx
+++ b/components/FAQSection.tsx
@@ -1,6 +1,23 @@
 'use client'
 
+'use client'
+
 import React, { useState } from 'react'
+
+// Google Ads コンバージョン追跡関数
+declare global {
+  interface Window {
+    gtag: (command: string, ...args: any[]) => void
+  }
+}
+
+const handleConversion = () => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', 'conversion', {
+      'send_to': 'AW-617366745/sCN4CI2u6I0bENmJsaYC'
+    })
+  }
+}
 
 const FAQSection = () => {
   const [openIndex, setOpenIndex] = useState<number | null>(0)
@@ -98,6 +115,7 @@ const FAQSection = () => {
               className="inline-flex items-center bg-green-600 hover:bg-green-700 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200"
               target="_blank"
               rel="noopener noreferrer"
+              onClick={handleConversion}
             >
               <span className="mr-2">💬</span>
               LINEで質問する

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,21 @@
+'use client'
+
 import React from 'react'
+
+// Google Ads コンバージョン追跡関数
+declare global {
+  interface Window {
+    gtag: (command: string, ...args: any[]) => void
+  }
+}
+
+const handleConversion = () => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', 'conversion', {
+      'send_to': 'AW-617366745/sCN4CI2u6I0bENmJsaYC'
+    })
+  }
+}
 
 const Footer = () => {
   return (
@@ -77,6 +94,7 @@ const Footer = () => {
                   className="inline-flex items-center bg-green-600 hover:bg-green-700 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200"
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={handleConversion}
                 >
                   <span className="bg-white text-green-600 px-2 py-1 rounded text-xs mr-2 font-bold">LINE</span>
                   無料相談はこちら

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,6 +3,21 @@
 import React, { useState, useEffect } from 'react'
 import Link from 'next/link'
 
+// Google Ads コンバージョン追跡関数
+declare global {
+  interface Window {
+    gtag: (command: string, ...args: any[]) => void
+  }
+}
+
+const handleConversion = () => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', 'conversion', {
+      'send_to': 'AW-617366745/sCN4CI2u6I0bENmJsaYC'
+    })
+  }
+}
+
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isScrolled, setIsScrolled] = useState(false)
@@ -82,6 +97,7 @@ const Header = () => {
               className="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg transition-all duration-200 text-sm flex items-center"
               target="_blank"
               rel="noopener noreferrer"
+              onClick={handleConversion}
             >
               <span className="bg-white text-green-600 px-1 py-0.5 rounded text-xs mr-2 font-bold">LINE</span>
               無料相談
@@ -141,6 +157,7 @@ const Header = () => {
                 className="block text-center bg-green-600 hover:bg-green-700 text-white font-semibold py-3 px-4 rounded-lg transition-all duration-200"
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={handleConversion}
               >
                 <span className="bg-white text-green-600 px-1 py-0.5 rounded text-xs mr-2 font-bold">LINE</span>
                 無料相談

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,5 +1,22 @@
+'use client'
+
 import React from 'react'
 import Link from 'next/link'
+
+// Google Ads コンバージョン追跡関数
+declare global {
+  interface Window {
+    gtag: (command: string, ...args: any[]) => void
+  }
+}
+
+const handleConversion = () => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', 'conversion', {
+      'send_to': 'AW-617366745/sCN4CI2u6I0bENmJsaYC'
+    })
+  }
+}
 
 const HeroSection = () => {
   return (
@@ -81,6 +98,7 @@ const HeroSection = () => {
               className="inline-flex items-center bg-green-600 hover:bg-green-700 text-white font-semibold py-4 px-8 rounded-lg text-lg transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
               target="_blank"
               rel="noopener noreferrer"
+              onClick={handleConversion}
             >
               <span className="bg-white text-green-600 px-2 py-1 rounded text-xs mr-3 font-bold">LINE</span>
               無料相談

--- a/components/PricingSection.tsx
+++ b/components/PricingSection.tsx
@@ -1,4 +1,21 @@
+'use client'
+
 import React from 'react'
+
+// Google Ads コンバージョン追跡関数
+declare global {
+  interface Window {
+    gtag: (command: string, ...args: any[]) => void
+  }
+}
+
+const handleConversion = () => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', 'conversion', {
+      'send_to': 'AW-617366745/sCN4CI2u6I0bENmJsaYC'
+    })
+  }
+}
 
 const PricingSection = () => {
   return (
@@ -116,6 +133,7 @@ const PricingSection = () => {
                   className="btn-primary w-full text-lg py-4 bg-red-600 hover:bg-red-700 mb-4 inline-block"
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={handleConversion}
                 >
                   今すぐ申し込む
                 </a>


### PR DESCRIPTION
## Summary
• 全LINE問い合わせボタンにGoogle Adsコンバージョン追跡を実装
• イベントスニペット (AW-617366745/sCN4CI2u6I0bENmJsaYC) でコンバージョンを記録
• 対象コンポーネント: CTASection, HeroSection, Header, Footer, PricingSection, FAQSection

## Test plan
- [x] ビルドテスト完了
- [x] 全コンポーネントでLINEボタンクリック時にコンバージョンイベント発火確認
- [ ] Google Ads管理画面でコンバージョン計測確認（本番環境での確認が必要）

🤖 Generated with [Claude Code](https://claude.ai/code)